### PR TITLE
Complete first release of claude-force

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         # Run system structure tests with coverage
         pytest test_claude_system.py -v --cov=claude_force --cov-report=xml --cov-report=term --override-ini="addopts="
         # Run performance tests (no coverage to avoid conflicts)
-        ANTHROPIC_API_KEY="test-key" pytest tests/test_async_orchestrator.py tests/test_response_cache.py tests/test_performance_integration.py -v --override-ini="addopts=" --no-cov
+        ANTHROPIC_API_KEY="test-key" pytest tests/test_async_orchestrator.py tests/test_response_cache.py tests/test_performance_integration.py -v --override-ini="addopts=" -p no:cov
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest test_claude_system.py -v --override-ini="addopts=" --no-cov
+          pytest test_claude_system.py -v --override-ini="addopts=" -p no:cov
 
       - name: Run security checks
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest test_claude_system.py -v --override-ini="addopts=" --no-cov
+          pytest test_claude_system.py -v --override-ini="addopts=" -p no:cov
 
       - name: Run security checks
         run: |


### PR DESCRIPTION
The --no-cov flag is not recognized by pytest. The correct way to disable coverage is using -p no:cov.

This fixes the release-candidate, release, and ci workflows that were failing due to this invalid flag.

Fixes #workflows