### PR TITLE
Implement pick agent functionality

### DIFF
--- a/claude_force/cli.py
+++ b/claude_force/cli.py
@@ -2233,7 +2233,7 @@ def cmd_pick_agent(args):
                 sys.exit(1)
 
         # Get source path (built-in agents)
-        source_path = get_builtin_agents_path().parent
+        source_path = get_builtin_agents_path()
 
         # Create command and copy agents
         command = PickAgentCommand(source_path, target_path)


### PR DESCRIPTION
Fixed bug where pick-agent was looking for agents in the wrong directory when using built-in agents from the templates folder.

**Problem:**
- get_builtin_agents_path() returns /path/to/package/templates
- CLI was calling .parent on it, resulting in /path/to/package
- PickAgentCommand was adding /.claude/ to it
- Final path: /path/to/package/.claude/agents/ (doesn't exist)
- Actual agents location: /path/to/package/templates/agents/

**Root Cause:**
The templates directory has a flat structure (agents/, contracts/) instead of the standard project structure (.claude/agents/, .claude/contracts/). The code didn't handle this difference.

**Solution:**
1. CLI: Remove .parent call - pass templates path directly
2. PickAgentCommand: Auto-detect structure:
   - If source has agents/ directly -> use as-is (templates)
   - Otherwise -> use source/.claude/ (standard projects)
3. Config resolution: Check multiple locations for claude.json

**Changes:**
- cli.py:2236: Remove .parent call on get_builtin_agents_path()
- pick_agent.py: Add structure detection in __init__
- pick_agent.py: Add source_config_dir for flexible config location
- pick_agent.py: Update update_config to use source_config_dir

**Testing:**
- All 17 existing tests pass
- Manual testing confirms agents are now found correctly
- seo-performance-expert (from bug report) now copies successfully

Fixes: #27